### PR TITLE
add breadcrumbMessageFromAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,15 @@ Sentry allows you to associate [tags] with each report.
 `getTags` allows you to define a mapping from your Redux `state` to
 an object of tags (key → value). Be careful not to mutate your `state`
 within this function.
+
+#### `breadcrumbMessageFromAction` _(Function)_
+
+Default: `action => action.type`
+
+`breadcrumbMessageFromAction` allows you to specify a transform function which is passed the `action` object and returns a `string` that will be used as the message of the breadcrumb.
+
+By default `breadcrumbMessageFromAction` returns `action.type`.
+
+Finally, be careful not to mutate your `action` within this function.
+
+See the Sentry [Breadcrumb documentation](https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript).

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,12 @@
 const identity = x => x;
 const getUndefined = () => {};
 const filter = () => true;
+const getType = action => action.type;
 
 const createSentryMiddleware = (Sentry, options = {}) => {
   const {
     breadcrumbDataFromAction = getUndefined,
+    breadcrumbMessageFromAction = getType,
     actionTransformer = identity,
     stateTransformer = identity,
     breadcrumbCategory = "redux-action",
@@ -43,7 +45,7 @@ const createSentryMiddleware = (Sentry, options = {}) => {
       if (filterBreadcrumbActions(action)) {
         Sentry.addBreadcrumb({
           category: breadcrumbCategory,
-          message: action.type,
+          message: breadcrumbMessageFromAction(action),
           level: "info",
           data: breadcrumbDataFromAction(action)
         });


### PR DESCRIPTION
Hello, @vidit-sh 

Sometimes it's necessary to use the different message of action breadcrumb instead of action.type.

The most common example is to process batched actions e.g:
```
{
  type: 'batch',
  payload: [
    {type: 'action-1'}, {type: 'action-2'}
  ]
}
```

Another use-case is to log actions with a different format e.g.
```
{
  ID: 123,
  ... 
}
```

At the moment we have to filter all the breadcrumbs. It would be great if redux-sentry-middleware has such feature from the box. So I have added `breadcrumbMessageFromAction` which allows defining a function to change a message of action. 