### PR TITLE
Fix - change scope to event to add tags to sentry request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-sentry-middleware",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Redux middleware for propagating Redux state/actions to use with new @sentry/browser and @sentry/node.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-sentry-middleware",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Redux middleware for propagating Redux state/actions to use with new @sentry/browser and @sentry/node.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ const createSentryMiddleware = (Sentry, options = {}) => {
         if (getTags) {
           const tags = getTags(state);
           Object.keys(tags).forEach(key => {
-            scope.tags = { ...scope.tags, [key]: tags[key] };
+            event.tags = { ...event.tags, [key]: tags[key] };
           });
         }
         return event;


### PR DESCRIPTION
Middleware was not adding tags to events posted to Sentry as the tags were being added to the scope instead